### PR TITLE
Firerate timer guns

### DIFF
--- a/chars/character_hand.gd
+++ b/chars/character_hand.gd
@@ -34,7 +34,7 @@ func reload(gun:Gun,currentScene,inventory:CharacterInventory):
 				gun.loadedMag = mag
 				magContainer.remove(mag)
 
-func fire(player:Player):
+func fire(player:Player, burst:bool=false):
 	if not (held_item is Gun):
 		return
 		
@@ -47,8 +47,8 @@ func fire(player:Player):
 		offset.y * side_y
 	)
 	#--------------------------------------------------------
-	
-	gun.fire(self, customOffset)
+	if (burst): gun.burstFire(self, customOffset)
+	else: gun.fire(self, customOffset)
 
 func equipFromItemSlot(item:Item, gunInfoUI:Panel):
 	if (item != null): 

--- a/chars/character_hand.gd
+++ b/chars/character_hand.gd
@@ -34,23 +34,21 @@ func reload(gun:Gun,currentScene,inventory:CharacterInventory):
 				gun.loadedMag = mag
 				magContainer.remove(mag)
 
-func changeFireMode(gun:Gun):
-	if (held_item is Gun):
-		if (gun.CAN_AUTO_FIRE):
-			gun.isAutoFireMode = !gun.isAutoFireMode
-
-func fire(gun:Gun, player:Player):
-	if (held_item is Gun):
-		# Some Dumb math code to properly spawn bullet at muzzle
-		var side_x = sign(cos(player.rotation))
-		var side_y = sign(sin(player.rotation))
-		var customOffset = Vector2(
-			offset.x * abs(side_x),
-			offset.y * side_y
-		)
-		#--------------------------------------------------------
+func fire(player:Player):
+	if not (held_item is Gun):
+		return
 		
-		gun.fire(self, customOffset)
+	var gun: Gun = held_item
+	# Some Dumb math code to properly spawn bullet at muzzle
+	var side_x = sign(cos(player.rotation))
+	var side_y = sign(sin(player.rotation))
+	var customOffset = Vector2(
+		offset.x * abs(side_x),
+		offset.y * side_y
+	)
+	#--------------------------------------------------------
+	
+	gun.fire(self, customOffset)
 
 func equipFromItemSlot(item:Item, gunInfoUI:Panel):
 	if (item != null): 

--- a/chars/scripts/player.gd
+++ b/chars/scripts/player.gd
@@ -49,8 +49,8 @@ func player_movement():
 	move_and_slide()
 
 func _process(delta: float) -> void:
-	print(characterPickupItem)
-	print(character_data.pickupsInRange)
+	#print(characterPickupItem)
+	#print(character_data.pickupsInRange)
 	
 	update_pickup_hover_ui()
 	
@@ -69,15 +69,20 @@ func _process(delta: float) -> void:
 		if (Input.is_action_just_pressed("secondary_weapon")): right_hand.equipFromItemSlot(character_data.inventory.secondaryWeapon, gun_info_ui)
 		
 		if (Input.is_action_just_pressed("pistol")): right_hand.equipFromItemSlot(character_data.inventory.pistol,gun_info_ui)
-		
-		if (Input.is_action_pressed("fire")): right_hand.fire(right_hand.held_item,self)
-
-		if (Input.is_action_just_pressed("fire mode")): right_hand.changeFireMode(right_hand.held_item)
 
 		if (Input.is_action_just_pressed("reload")): right_hand.reload(right_hand.held_item,currentScene,character_data.inventory)
 
 		if (right_hand.held_item is Gun):
-			gun_info_ui.update(right_hand.held_item)
+			var held_gun:Gun = right_hand.held_item
+			match held_gun.fire_mode:
+				Gun.FIRE_MODES.SEMI:
+					if (Input.is_action_just_pressed("fire")): right_hand.fire(self)
+				Gun.FIRE_MODES.AUTO:
+					if (Input.is_action_pressed("fire")): right_hand.fire(self)
+				# TODO Add Burst Fire
+			
+			if (Input.is_action_just_pressed("fire_mode")): held_gun.cycleFireMode()
+			gun_info_ui.update(held_gun)
 			gun_info_ui.showHide(true)
 		else:
 			gun_info_ui.showHide(false)

--- a/chars/scripts/player.gd
+++ b/chars/scripts/player.gd
@@ -79,7 +79,8 @@ func _process(delta: float) -> void:
 					if (Input.is_action_just_pressed("fire")): right_hand.fire(self)
 				Gun.FIRE_MODES.AUTO:
 					if (Input.is_action_pressed("fire")): right_hand.fire(self)
-				# TODO Add Burst Fire
+				Gun.FIRE_MODES.BURST:
+					if (Input.is_action_just_pressed("fire")): right_hand.fire(self, true)
 			
 			if (Input.is_action_just_pressed("fire_mode")): held_gun.cycleFireMode()
 			gun_info_ui.update(held_gun)

--- a/pickups/guns/data/Ak47.tres
+++ b/pickups/guns/data/Ak47.tres
@@ -7,8 +7,8 @@
 script = ExtResource("2_dg3xg")
 AMMO_TYPE = "7.62"
 FIRERATE = 0.1
-CAN_AUTO_FIRE = true
-isAutoFireMode = false
+available_fire_modes = Array[int]([0, 1])
+fire_mode = 0
 ATTACHMENT_POINTS = {
 "Muzzle": Vector2(36, -6),
 "PistolGrip": Vector2(-14, 0)

--- a/pickups/guns/data/Ak47.tres
+++ b/pickups/guns/data/Ak47.tres
@@ -5,6 +5,7 @@
 
 [resource]
 script = ExtResource("2_dg3xg")
+BURST_SIZE = 3
 AMMO_TYPE = "7.62"
 FIRERATE = 0.1
 available_fire_modes = Array[int]([0, 1])

--- a/pickups/guns/data/Colt45.tres
+++ b/pickups/guns/data/Colt45.tres
@@ -7,8 +7,8 @@
 script = ExtResource("3_44jkn")
 AMMO_TYPE = ".45 ACP"
 FIRERATE = 0.2
-CAN_AUTO_FIRE = false
-isAutoFireMode = false
+available_fire_modes = Array[int]([0])
+fire_mode = 0
 ATTACHMENT_POINTS = {
 "Muzzle": Vector2(22, -6),
 "PistolGrip": Vector2(-14, 0)

--- a/pickups/guns/scripts/gun.gd
+++ b/pickups/guns/scripts/gun.gd
@@ -15,6 +15,7 @@ const BULLET = preload("res://pickups/bullets/bullet.tscn")
 @export var ATTACHMENT_POINTS:Dictionary = {"Muzzle":Vector2(), "PistolGrip":Vector2()}
 
 var last_fire_time: float = 0.0
+var is_bursting: bool = false
 # ------------------
 
 func canFire() -> bool:
@@ -32,12 +33,36 @@ func cycleFireMode() -> void:
 	var idx := available_fire_modes.find(fire_mode)
 	idx = (idx + 1) % available_fire_modes.size()
 	fire_mode = available_fire_modes[idx]
+	
+func burstFire(hand: CharacterHand, offset: Vector2) -> void:
+	var BURST_SIZE = 3
+	if is_bursting:
+		return
+	if not canFire() or (Time.get_ticks_msec()/1000.0 - last_fire_time) < FIRERATE:
+		return
+
+	is_bursting = true
+	var burstLeft = BURST_SIZE
+	if loadedMag.currentAmmo - BURST_SIZE < 0:
+		burstLeft = loadedMag.currentAmmo
+
+	for i in range(burstLeft):
+		_shoot(hand, offset)
+		if i < burstLeft - 1:
+			await hand.get_tree().create_timer(FIRERATE).timeout
+
+	last_fire_time = Time.get_ticks_msec() / 1000.0
+	is_bursting = false
 
 func fire(hand: CharacterHand, offset: Vector2) -> void:
 	var now := Time.get_ticks_msec() / 1000.0
 	if canFire() and (now - last_fire_time) >= FIRERATE:
-		var bullet = createBullet()
-		var bulletPOS: Vector2 = hand.global_position + offset.rotated(hand.global_rotation) + ATTACHMENT_POINTS["Muzzle"].rotated(hand.global_rotation)
-		loadedMag.removeAmmo(1)
-		BulletManager.spawn_bullet(bullet, bulletPOS, hand.global_rotation)
+		_shoot(hand, offset)
 		last_fire_time = now
+		
+func _shoot(hand: CharacterHand, offset: Vector2):
+	var bullet = createBullet()
+	var bulletPOS: Vector2 = hand.global_position + offset.rotated(hand.global_rotation) + ATTACHMENT_POINTS["Muzzle"].rotated(hand.global_rotation)
+	loadedMag.removeAmmo(1)
+	BulletManager.spawn_bullet(bullet, bulletPOS, hand.global_rotation)
+	

--- a/pickups/guns/scripts/gun.gd
+++ b/pickups/guns/scripts/gun.gd
@@ -2,16 +2,19 @@
 extends GunProperties
 class_name Gun
 
+enum FIRE_MODES { SEMI, AUTO, BURST }
+
 @export var AMMO_TYPE:String
 @export var FIRERATE:float
-@export var CAN_AUTO_FIRE:bool
 
 const BULLET = preload("res://pickups/bullets/bullet.tscn")
 
-@export var isAutoFireMode = false
+@export var available_fire_modes: Array[FIRE_MODES] = [FIRE_MODES.SEMI, FIRE_MODES.AUTO]
+@export var fire_mode: FIRE_MODES = FIRE_MODES.SEMI
 @export var loadedMag:Mag
 @export var ATTACHMENT_POINTS:Dictionary = {"Muzzle":Vector2(), "PistolGrip":Vector2()}
 
+var last_fire_time: float = 0.0
 # ------------------
 
 func canFire() -> bool:
@@ -25,9 +28,16 @@ func createBullet() -> Area2D:
 	bullet_instance.gunName = NAME
 	return bullet_instance
 
-func fire(hand:CharacterHand, offset:Vector2):
-	if (canFire()):
+func cycleFireMode() -> void:
+	var idx := available_fire_modes.find(fire_mode)
+	idx = (idx + 1) % available_fire_modes.size()
+	fire_mode = available_fire_modes[idx]
+
+func fire(hand: CharacterHand, offset: Vector2) -> void:
+	var now := Time.get_ticks_msec() / 1000.0
+	if canFire() and (now - last_fire_time) >= FIRERATE:
 		var bullet = createBullet()
-		var bulletPOS:Vector2 = hand.global_position + offset.rotated(hand.global_rotation) + ATTACHMENT_POINTS["Muzzle"].rotated(hand.global_rotation)
+		var bulletPOS: Vector2 = hand.global_position + offset.rotated(hand.global_rotation) + ATTACHMENT_POINTS["Muzzle"].rotated(hand.global_rotation)
 		loadedMag.removeAmmo(1)
 		BulletManager.spawn_bullet(bullet, bulletPOS, hand.global_rotation)
+		last_fire_time = now

--- a/pickups/guns/scripts/gun.gd
+++ b/pickups/guns/scripts/gun.gd
@@ -4,6 +4,7 @@ class_name Gun
 
 enum FIRE_MODES { SEMI, AUTO, BURST }
 
+@export var BURST_SIZE:int = 3
 @export var AMMO_TYPE:String
 @export var FIRERATE:float
 
@@ -35,7 +36,6 @@ func cycleFireMode() -> void:
 	fire_mode = available_fire_modes[idx]
 	
 func burstFire(hand: CharacterHand, offset: Vector2) -> void:
-	var BURST_SIZE = 3
 	if is_bursting:
 		return
 	if not canFire() or (Time.get_ticks_msec()/1000.0 - last_fire_time) < FIRERATE:

--- a/project.godot
+++ b/project.godot
@@ -67,7 +67,7 @@ throw={
 "events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":81,"key_label":0,"unicode":113,"location":0,"echo":false,"script":null)
 ]
 }
-"fire mode"={
+fire_mode={
 "deadzone": 0.2,
 "events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":66,"key_label":0,"unicode":98,"location":0,"echo":false,"script":null)
 ]

--- a/ui/scripts/gun_info_ui.gd
+++ b/ui/scripts/gun_info_ui.gd
@@ -5,7 +5,7 @@ extends Panel
 
 func update(gun:Gun):
 	ammo_type_label.text = gun.AMMO_TYPE
-	firerate_mode_label.text = str(gun.isAutoFireMode)
+	firerate_mode_label.text = str(Gun.FIRE_MODES.find_key(gun.fire_mode))
 	if (gun.loadedMag):
 		current_ammo_label.text = str(gun.loadedMag.currentAmmo)+"/"+str(gun.loadedMag.AMMO_CAPACITY)
 	else:


### PR DESCRIPTION
## Description

Resolves: #11

## Summary

| Aspect | Details |
|--------|---------|
| **Author** | @donnie58744 |
| **State** | Open (not merged) |
| **Draft** | No |
| **Commits** | 3 |
| **Files Changed** | 7 |
| **Lines Added/Deleted** | +77 / -37 |
| **Comments** | 0 |
| **Mergeable** | Yes, but blocked |
| **Labels** | enhancement |

## Key Changes

**Gun System Architecture:**
- Replaced `CAN_AUTO_FIRE` boolean and `isAutoFireMode` state with an `FIRE_MODES` enum (SEMI, AUTO, BURST)
- Added `available_fire_modes` array to specify which modes each gun supports
- Introduced fire rate timing tracking (`last_fire_time`) to enforce proper delays between shots

**Gun Firing Logic:**
- Implemented `cycleFireMode()` method to switch between available fire modes
- Created `burstFire()` method for 3-round burst shots with proper timing
- Refactored `fire()` method to use time-based rate limiting instead of instant firing
- Extracted actual bullet spawning into a new `_shoot()` helper method

**Player Input Handling:**
- Removed the `changeFireMode()` method from character_hand and moved fire mode cycling directly to the gun
- Refactored input processing to use a `match` statement on `fire_mode`:
  - SEMI: fires on key press (`is_action_just_pressed`)
  - AUTO: fires while held (`is_action_pressed`)
  - BURST: fires x-round burst on key press
- Simplified the `fire()` call to no longer pass the gun object as parameter

**Gun Configuration:**
- Updated AK47 and Colt45 gun data files to use the new `available_fire_modes` and `fire_mode` properties
- AK47 supports both SEMI and AUTO modes; Colt45 supports only SEMI

**Minor Updates:**
- Renamed "fire mode" input action to `fire_mode` (lowercase) in project.godot
- Commented out debug print statements in player.gd
- Updated UI display to show fire mode name instead of boolean