### PR TITLE
Remove unused drag code

### DIFF
--- a/chars/inv/ui/scripts/character_inventory_ui.gd
+++ b/chars/inv/ui/scripts/character_inventory_ui.gd
@@ -8,8 +8,6 @@ extends Control
 @export var slots: Array[ItemSlot]
 
 var showInventory:bool = false
-var draggingItem:DragableItem
-var drag_offset
 var slotMoveInto:ItemSlot
 
 class DragState:
@@ -32,11 +30,6 @@ var drag := DragState.new()
 func _ready() -> void:
 	visible = false
 	update_slots()
-
-func resetDrag():
-	draggingItem.queue_free()
-	draggingItem = null
-	slotMoveInto = null
 
 func connectDragSig(slot:ItemSlot):
 	if (!slot.is_connected("gui_input",Callable(self, "slot_gui_input").bind(slot))):


### PR DESCRIPTION
### Remove unused drag code

**Type Of Change**
- [x] Refactor
- [ ] Bug fix (non-breaking change which fixes an issue) 
- [ ] New feature (non-breaking change which adds functionality) 
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) 
- [ ] This change requires a documentation update
 
**Description**
Removes unused draggingItem, drag_offset variables and resetDrag() function from the inventory UI system.

**Feature(s)**
- Resolves: #(issue)

**Changes**
Removes unused draggingItem, drag_offset variables and resetDrag() function from the inventory UI system.

**Dependencies**


**Test**


**Checklist**
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules